### PR TITLE
Apply minor modifications

### DIFF
--- a/OpenSCENARIO/NCAP/AEB_C2C_2023/NCAP_AEB_C2C_CCFtap_2023.xosc
+++ b/OpenSCENARIO/NCAP/AEB_C2C_2023/NCAP_AEB_C2C_CCFtap_2023.xosc
@@ -165,7 +165,7 @@
         <Private entityRef="Target">
           <PrivateAction>
             <RoutingAction>
-              <FollowTrajectoryAction>
+              <FollowTrajectoryAction initialDistanceOffset="$Target_initS">
                 <TimeReference>
                   <None />
                 </TimeReference>
@@ -176,18 +176,6 @@
                 </TrajectoryRef>
               </FollowTrajectoryAction>
             </RoutingAction>
-          </PrivateAction>
-          <PrivateAction>
-            <TeleportAction>
-              <Position>
-                <TrajectoryPosition s="$Target_initS">
-                  <TrajectoryRef>
-                    <CatalogReference catalogName="TrajectoryCatalog" entryName="Target_straightAcross">
-                    </CatalogReference>
-                  </TrajectoryRef>
-                </TrajectoryPosition>
-              </Position>
-            </TeleportAction>
           </PrivateAction>
         </Private>
       </Actions>

--- a/OpenSCENARIO/NCAP/AEB_VRU_2023/NCAP_AEB_VRU_CPRA_Cm_2023.xosc
+++ b/OpenSCENARIO/NCAP/AEB_VRU_2023/NCAP_AEB_VRU_CPRA_Cm_2023.xosc
@@ -80,6 +80,16 @@
         </GlobalAction>
         <Private entityRef="Ego">
           <PrivateAction>
+            <LongitudinalAction>
+              <SpeedAction>
+                <SpeedActionDynamics dynamicsDimension="time" dynamicsShape="step" value="0" />
+                <SpeedActionTarget>
+                  <AbsoluteTargetSpeed value="$_Ego_speed" />
+                </SpeedActionTarget>
+              </SpeedAction>
+            </LongitudinalAction>
+          </PrivateAction>
+          <PrivateAction>
             <RoutingAction>
               <FollowTrajectoryAction>
                 <TimeReference>
@@ -96,16 +106,6 @@
                 </TrajectoryRef>
               </FollowTrajectoryAction>
             </RoutingAction>
-          </PrivateAction>
-          <PrivateAction>
-            <LongitudinalAction>
-              <SpeedAction>
-                <SpeedActionDynamics dynamicsDimension="time" dynamicsShape="step" value="0" />
-                <SpeedActionTarget>
-                  <AbsoluteTargetSpeed value="$_Ego_speed" />
-                </SpeedActionTarget>
-              </SpeedAction>
-            </LongitudinalAction>
           </PrivateAction>
           <PrivateAction>
             <TeleportAction>

--- a/OpenSCENARIO/NCAP/AEB_VRU_2023/NCAP_AEB_VRU_CPRA_Cs_2023.xosc
+++ b/OpenSCENARIO/NCAP/AEB_VRU_2023/NCAP_AEB_VRU_CPRA_Cs_2023.xosc
@@ -69,6 +69,16 @@
         </GlobalAction>
         <Private entityRef="Ego">
           <PrivateAction>
+            <LongitudinalAction>
+              <SpeedAction>
+                <SpeedActionDynamics dynamicsDimension="time" dynamicsShape="step" value="0" />
+                <SpeedActionTarget>
+                  <AbsoluteTargetSpeed value="$_Ego_speed" />
+                </SpeedActionTarget>
+              </SpeedAction>
+            </LongitudinalAction>
+          </PrivateAction>
+          <PrivateAction>
             <RoutingAction>
               <FollowTrajectoryAction>
                 <TimeReference>
@@ -85,16 +95,6 @@
                 </TrajectoryRef>
               </FollowTrajectoryAction>
             </RoutingAction>
-          </PrivateAction>
-          <PrivateAction>
-            <LongitudinalAction>
-              <SpeedAction>
-                <SpeedActionDynamics dynamicsDimension="time" dynamicsShape="step" value="0" />
-                <SpeedActionTarget>
-                  <AbsoluteTargetSpeed value="$_Ego_speed" />
-                </SpeedActionTarget>
-              </SpeedAction>
-            </LongitudinalAction>
           </PrivateAction>
           <PrivateAction>
             <TeleportAction>


### PR DESCRIPTION
_Sorry, I just saw from "contributing guidelines" that Pull Requests are not accepted yet. I will be rebellion enough to post it anyway since it was prepared. Feel free to close it or do whatever, e.g. cherry pick from the proposed changes._ 

With reference to esmini issue [#705](https://github.com/esmini/esmini/issues/705)

First: Great that more scenarios have been added to this suite! As before, you're making full use of the flexibility of the OpenSCENARIO XML standard in terms of catalogs and parameterization. Nice work!

While checking the scenarios in esmini I found not only the root cause of the reported issue, but also stumbled on two other issues. 

The first issue, in esmini, was a shortcoming in [`SynchronizeAction`](https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/SynchronizeAction.html) distance handling, not supporting reversing. This is a clear shortcoming and has now been fixed by commit [630c31](https://github.com/esmini/esmini/commit/630c316f5a675924e4048a69e6d6793023a4d35b) on dev branch. It will be included in next release.

To overcome the other issues we made minor modifications of the scenarios. For now, these modifications are done on a separate fork and branch: https://github.com/eknabevcc/OSC-NCAP-scenarios/tree/minor_modifications. 

esmini CI has switched to this branch for now. By this pull request we hope to soon switch back to upstream repo.

Let's walk through the proposed scenario modifications one by one:

### NCAP_AEB_C2C_CCFtap_2023.xosc

The initial position of Target is on the assigned trajectory at some s-distance along the trajectory. In this scenario it's achieved by adding a `TeleportAction` after the [`FollowTrajectoryAction`](https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/FollowTrajectoryAction.html) in the Init section.

Another appropriate and more direct approach is to make use of the `initialDistanceOffset` attribute of the `FollowTrajectoryAction`. It's cleaner and easier. 

Explanation for unexpected result in esmini: The FollowTrajectory action will override the position given by the TeleportAction. 

It can be argued if and how a Teleport action should affect any ongoing FollowTrajectory action. But for this case we can avoid that complexity by using the provided attribute instead.

### NCAP_AEB_VRU_CPRA_Cm_2023.xosc and NCAP_AEB_VRU_CPRA_Cs_2023.xosc

In esmini, when initializing a [`FollowTrajectoryAction`](https://publications.pages.asam.net/standards/ASAM_OpenSCENARIO/ASAM_OpenSCENARIO_XML/latest/generated/content/FollowTrajectoryAction.html), the speed sign (foward/reverse) will affect the orientation of the entity (as long as no explicit orientation has been specified). So, for example, a negative speed will place the entity in opposite s-direction and move along s-axis, in effect reversing.

Why does this not work with this scenario: At the initialization of the FollowingTrajectoryAction the speed is zero - since the SpeedAction has not yet been applied. Hence the orientation of entity points along s-axis. Then, when starting to reverse (according to negative speed), it will immediately move away from the trajectory.

The simple solution is to establish the speed first, and then the trajectory. Just swap the order of those two actions.

(for details regarding esmini handling of trajectories, see esmini User guide [here](https://esmini.github.io/#_trajectories))

