### PR TITLE
Make init sections more concise

### DIFF
--- a/OpenSCENARIO/NCAP/AEB_C2C_2023/NCAP_AEB_C2C_CCFtap_2023.xosc
+++ b/OpenSCENARIO/NCAP/AEB_C2C_2023/NCAP_AEB_C2C_CCFtap_2023.xosc
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='utf-8'?>
 <OpenSCENARIO xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="OpenSCENARIO.xsd">
-  <!--Copyright (c) 2025, Vector Informatik GmbH--><FileHeader revMajor="1" revMinor="3" date="2025-02-20T09:09:29" author="Vector Informatik GmbH" description="Base Scenario for NCAP AEB C2C CCFtap and (through variation) CMFtap"><License name="Mozilla Public License Version 2.0" resource="https://www.mozilla.org/en-US/MPL/2.0/" spdxId="MPL-2.0" /></FileHeader>
+  <!--Copyright (c) 2024-2025, Vector Informatik GmbH-->
+  <FileHeader revMajor="1" revMinor="3" date="2025-08-27T09:09:29" author="Vector Informatik GmbH" description="Base Scenario for NCAP AEB C2C CCFtap and (through variation) CMFtap">
+    <License name="Mozilla Public License Version 2.0" resource="https://www.mozilla.org/en-US/MPL/2.0/" spdxId="MPL-2.0" />
+  </FileHeader>
   <ParameterDeclarations>
     <ParameterDeclaration name="Ego_speed_kph" parameterType="double" value="10" />
     <ParameterDeclaration name="Ego_initS" parameterType="double" value="90"><!--initial advance of Ego entity-->
@@ -165,7 +168,7 @@
         <Private entityRef="Target">
           <PrivateAction>
             <RoutingAction>
-              <FollowTrajectoryAction>
+              <FollowTrajectoryAction initialDistanceOffset="$Target_initS">
                 <TimeReference>
                   <None />
                 </TimeReference>
@@ -176,18 +179,6 @@
                 </TrajectoryRef>
               </FollowTrajectoryAction>
             </RoutingAction>
-          </PrivateAction>
-          <PrivateAction>
-            <TeleportAction>
-              <Position>
-                <TrajectoryPosition s="$Target_initS">
-                  <TrajectoryRef>
-                    <CatalogReference catalogName="TrajectoryCatalog" entryName="Target_straightAcross">
-                    </CatalogReference>
-                  </TrajectoryRef>
-                </TrajectoryPosition>
-              </Position>
-            </TeleportAction>
           </PrivateAction>
         </Private>
       </Actions>

--- a/OpenSCENARIO/NCAP/AEB_VRU_2023/NCAP_AEB_VRU_CPRA_Cm_2023.xosc
+++ b/OpenSCENARIO/NCAP/AEB_VRU_2023/NCAP_AEB_VRU_CPRA_Cm_2023.xosc
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='utf-8'?>
 <OpenSCENARIO xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="OpenSCENARIO.xsd">
-  <!--Copyright (c) 2025, Vector Informatik GmbH--><FileHeader revMajor="1" revMinor="3" date="2025-02-20T09:09:29" author="Vector Informatik GmbH" description="Base Scenario for NCAP AEB VRU CPRAm and (through variation) CPRCm"><License name="Mozilla Public License Version 2.0" resource="https://www.mozilla.org/en-US/MPL/2.0/" spdxId="MPL-2.0" /></FileHeader>
+  <!--Copyright (c) 2024-2025, Vector Informatik GmbH-->
+  <FileHeader revMajor="1" revMinor="3" date="2025-08-27T13:34:51" author="Vector Informatik GmbH" description="Base Scenario for NCAP AEB VRU CPRAm and (through variation) CPRCm">
+    <License name="Mozilla Public License Version 2.0" resource="https://www.mozilla.org/en-US/MPL/2.0/" spdxId="MPL-2.0" />
+  </FileHeader>
   <ParameterDeclarations>
     <ParameterDeclaration name="Ego_speed_kph" parameterType="double" value="4" />
     <ParameterDeclaration name="Ego_initDist" parameterType="double" value="10"><!--initial distance of Ego to collision point L as defined in NCAP protocol--><!--value not explicitly provided in NCAP protocol-->
@@ -80,6 +83,16 @@
         </GlobalAction>
         <Private entityRef="Ego">
           <PrivateAction>
+            <LongitudinalAction>
+              <SpeedAction>
+                <SpeedActionDynamics dynamicsDimension="time" dynamicsShape="step" value="0" />
+                <SpeedActionTarget>
+                  <AbsoluteTargetSpeed value="$_Ego_speed" />
+                </SpeedActionTarget>
+              </SpeedAction>
+            </LongitudinalAction>
+          </PrivateAction>
+          <PrivateAction>
             <RoutingAction>
               <FollowTrajectoryAction>
                 <TimeReference>
@@ -96,16 +109,6 @@
                 </TrajectoryRef>
               </FollowTrajectoryAction>
             </RoutingAction>
-          </PrivateAction>
-          <PrivateAction>
-            <LongitudinalAction>
-              <SpeedAction>
-                <SpeedActionDynamics dynamicsDimension="time" dynamicsShape="step" value="0" />
-                <SpeedActionTarget>
-                  <AbsoluteTargetSpeed value="$_Ego_speed" />
-                </SpeedActionTarget>
-              </SpeedAction>
-            </LongitudinalAction>
           </PrivateAction>
           <PrivateAction>
             <TeleportAction>

--- a/OpenSCENARIO/NCAP/AEB_VRU_2023/NCAP_AEB_VRU_CPRA_Cs_2023.xosc
+++ b/OpenSCENARIO/NCAP/AEB_VRU_2023/NCAP_AEB_VRU_CPRA_Cs_2023.xosc
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='utf-8'?>
 <OpenSCENARIO xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="OpenSCENARIO.xsd">
-  <!--Copyright (c) 2025, Vector Informatik GmbH--><FileHeader revMajor="1" revMinor="3" date="2025-02-20T09:09:29" author="Vector Informatik GmbH" description="Base Scenario for NCAP AEB VRU CPRA/Cs"><License name="Mozilla Public License Version 2.0" resource="https://www.mozilla.org/en-US/MPL/2.0/" spdxId="MPL-2.0" /></FileHeader>
+  <!--Copyright (c) 2024-2025, Vector Informatik GmbH-->
+  <FileHeader revMajor="1" revMinor="3" date="2025-08-27T13:34:51" author="Vector Informatik GmbH" description="Base Scenario for NCAP AEB VRU CPRA/Cs">
+    <License name="Mozilla Public License Version 2.0" resource="https://www.mozilla.org/en-US/MPL/2.0/" spdxId="MPL-2.0" />
+  </FileHeader>
   <ParameterDeclarations>
     <ParameterDeclaration name="Ego_speed_kph" parameterType="double" value="4" />
     <ParameterDeclaration name="Ego_initDist" parameterType="double" value="10"><!--initial distance of Ego to collision point L as defined in NCAP protocol--><!--value not explicitly provided in NCAP protocol-->
@@ -69,6 +72,16 @@
         </GlobalAction>
         <Private entityRef="Ego">
           <PrivateAction>
+            <LongitudinalAction>
+              <SpeedAction>
+                <SpeedActionDynamics dynamicsDimension="time" dynamicsShape="step" value="0" />
+                <SpeedActionTarget>
+                  <AbsoluteTargetSpeed value="$_Ego_speed" />
+                </SpeedActionTarget>
+              </SpeedAction>
+            </LongitudinalAction>
+          </PrivateAction>
+          <PrivateAction>
             <RoutingAction>
               <FollowTrajectoryAction>
                 <TimeReference>
@@ -85,16 +98,6 @@
                 </TrajectoryRef>
               </FollowTrajectoryAction>
             </RoutingAction>
-          </PrivateAction>
-          <PrivateAction>
-            <LongitudinalAction>
-              <SpeedAction>
-                <SpeedActionDynamics dynamicsDimension="time" dynamicsShape="step" value="0" />
-                <SpeedActionTarget>
-                  <AbsoluteTargetSpeed value="$_Ego_speed" />
-                </SpeedActionTarget>
-              </SpeedAction>
-            </LongitudinalAction>
           </PrivateAction>
           <PrivateAction>
             <TeleportAction>


### PR DESCRIPTION
- adapt changes proposed by Emil Knabe:
- use initialDistanceOffset attribute and drop dedicated teleport action where applicable
- swap SpeedAction and FollowTrajectoryAction for reverse driving scenarios